### PR TITLE
Tweak to "hide" the .call argument from models() function

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -52,7 +52,7 @@ print.chat_tibble <- function(x, ...) {
 #' @export
 chat <- function(text = "What are the top 5 R packages ?", model = "mistral-tiny") {
 
-  available_models <- models(.call = current_env())
+  available_models <- models()
   if (!(model %in% available_models)) {
     cli::cli_abort(c(
       glue::glue("The model {model} is not available."),

--- a/R/models.R
+++ b/R/models.R
@@ -6,14 +6,9 @@
 #' models()
 #'
 #' @export
-models <- function(.call = caller_env()) {
+models <- function() {
 
-  req <- request(mistral_base_url) |>
-    req_url_path_append("v1", "models") |>
-    authenticate(.call = .call) |>
-    req_cache(tempdir(),
-              use_on_error = TRUE,
-              max_age = 2 * 60 * 60) # 2 hours
+  req <- req_models()
 
   resp <- req_perform(req) |>
     resp_body_json(simplifyVector = T)
@@ -22,4 +17,17 @@ models <- function(.call = caller_env()) {
     purrr::pluck("data","id")
 
   return(models)
+}
+
+
+req_models <- function(.call = caller_env()) {
+
+  req <- request(mistral_base_url) |>
+    req_url_path_append("v1", "models") |>
+    authenticate(.call = .call) |>
+    req_cache(tempdir(),
+              use_on_error = TRUE,
+              max_age = 2 * 60 * 60) # 2 hours
+
+  req
 }


### PR DESCRIPTION
No more `.call` argument in models() (because it does not make a lot of sense for end user) while keep complaining about the right function:

``` r
devtools::load_all()
#> ℹ Loading mistral.ai

chat("in short, which mistral model is the best one ?", model = "super-model")
#> Error in `chat()`:
#> ! The model super-model is not available.
#> ℹ Please use the `models()` function to see the available models.
#> Backtrace:
#>     ▆
#>  1. └─mistral.ai::chat("in short, which mistral model is the best one ?", model = "super-model")
#>  2.   └─cli::cli_abort(...) at mistral.ai/R/chat.R:57:4
#>  3.     └─rlang::abort(...)
```

<sup>Created on 2024-03-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Maybe a bit "hacky" :/
