### PR TITLE
simplify authenticate()

### DIFF
--- a/R/authenticate.R
+++ b/R/authenticate.R
@@ -1,11 +1,3 @@
-authenticate <- function(request, dry_run = FALSE, error_call = caller_env()){
-  key <- Sys.getenv("MISTRAL_API_KEY")
-  if (!is_true(dry_run) && identical(key, "")) {
-    cli_abort(call = error_call, c(
-      "Please set the {.code MISTRAL_API_KEY} environment variable",
-      i = "Get an API key from {.url https://console.mistral.ai/api-keys/}",
-      i = "Use {.code usethis::edit_r_environ()} to set the {.code MISTRAL_API_KEY} environment variable"
-    ))
-  }
-  req_auth_bearer_token(request, key)
+authenticate <- function(request){
+  req_auth_bearer_token(request, Sys.getenv("MISTRAL_API_KEY"))
 }

--- a/R/chat.R
+++ b/R/chat.R
@@ -28,7 +28,7 @@ req_chat <- function(text = "What are the top 5 R packages ?", model = "mistral-
   }
   request(mistral_base_url) |>
     req_url_path_append("v1", "chat", "completions") |>
-    authenticate(error_call = error_call, dry_run = dry_run) |>
+    authenticate() |>
     req_body_json(
       list(
         model = model,

--- a/R/models.R
+++ b/R/models.R
@@ -11,7 +11,7 @@
 models <- function(error_call = caller_env(), dry_run = FALSE) {
   req <- request(mistral_base_url) |>
     req_url_path_append("v1", "models") |>
-    authenticate(error_call = call, dry_run = dry_run) |>
+    authenticate() |>
     req_cache(tempdir(),
               use_on_error = TRUE,
               max_age = 2 * 60 * 60) # 2 hours


### PR DESCRIPTION
closes #17

This way we get the same error as if the key was wrong: 

``` r
mistral.ai::chat("hello")
#> Error in `mistral.ai::chat()`:
#> ✖ with endpoint <https://api.mistral.ai/v1/models>
#> ℹ Make sure your api key is valid <https://console.mistral.ai/api-keys/>
#> ℹ And set the `MISTRAL_API_KEY` environment variable
#> ℹ Perhaps using `usethis::edit_r_environ()`
#> Caused by error in `req_perform()` at mistral.ai/R/httr2.R:22:3:
#> ! HTTP 401 Unauthorized.
```

<sup>Created on 2024-03-09 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

 