### PR TITLE
check_model() uses rlang::arg_match()

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -26,14 +26,7 @@ models <- function(error_call = caller_env(), dry_run = FALSE) {
 }
 
 check_model <- function(model, error_call = caller_env()) {
-  available_models <- models(error_call = error_call)
-
-  if (!(model %in% available_models)) {
-    cli_abort(call = error_call, c(
-      "The model {model} is not available.",
-      "i" = "Please use the {.code models()} function to see the available models."
-    ))
-  }
-
+  candidates <- models(error_call = error_call)
+  arg_match(model, values = candidates, error_call = error_call)
   invisible(model)
 }


### PR DESCRIPTION
```
> mistral.ai::chat("hello", model = "fzzfz")
Error in `mistral.ai::chat()`:
! `model` must be one of "open-mistral-7b", "mistral-tiny-2312", "mistral-tiny", "open-mixtral-8x7b", "mistral-small-2312",
  "mistral-small", "mistral-small-2402", "mistral-small-latest", "mistral-medium-latest", "mistral-medium-2312", "mistral-medium",
  "mistral-large-latest", "mistral-large-2402", or "mistral-embed", not "fzzfz".
Run `rlang::last_trace()` to see where the error occurred.
```